### PR TITLE
feat: ignore minimum check when a number field is empty

### DIFF
--- a/src/lib/core/components/Form/__tests__/DynamicField.test.tsx
+++ b/src/lib/core/components/Form/__tests__/DynamicField.test.tsx
@@ -177,7 +177,6 @@ test('Form/hooks/DynamicField', () => {
 
     const errors = {
         name: false,
-        'name.id': ErrorMessages.minNumber(10),
         'name.name': ErrorMessages.REQUIRED,
         'name.description': ErrorMessages.REQUIRED,
         'name.settings': ErrorMessages.REQUIRED,
@@ -213,7 +212,6 @@ test('Form/hooks/DynamicField', () => {
 
     const errors1 = {
         name: false,
-        'name.id': ErrorMessages.minNumber(10),
         'name.name': ErrorMessages.REQUIRED,
         'name.description': ErrorMessages.REQUIRED,
         'name.settings': ErrorMessages.REQUIRED,
@@ -250,7 +248,6 @@ test('Form/hooks/DynamicField', () => {
 
     const errors2 = {
         name: false,
-        'name.id': ErrorMessages.minNumber(10),
         'name.name': ErrorMessages.REQUIRED,
         'name.description': ErrorMessages.REQUIRED,
         'name.settings': ErrorMessages.REQUIRED,
@@ -322,7 +319,7 @@ test('Form/hooks/DynamicField', () => {
 
     const errors4 = {
         name: false,
-        'name.id': ErrorMessages.minNumber(10),
+        'name.id': false,
         'name.name': ErrorMessages.REQUIRED,
         'name.description': ErrorMessages.REQUIRED,
         'name.settings': ErrorMessages.REQUIRED,
@@ -372,7 +369,7 @@ test('Form/hooks/DynamicField', () => {
 
     const errors5 = {
         name: false,
-        'name.id': ErrorMessages.minNumber(10),
+        'name.id': false,
         'name.name': ErrorMessages.REQUIRED,
         'name.description': ErrorMessages.REQUIRED,
         'name.settings': ErrorMessages.REQUIRED,

--- a/src/lib/kit/validators/__tests__/validators.test.ts
+++ b/src/lib/kit/validators/__tests__/validators.test.ts
@@ -83,6 +83,7 @@ describe('kit/validators/validators', () => {
         spec.minimum = 100.5;
 
         expect(getNumberValidator({ignoreMinimumCheck: true})(spec, '1.01')).toBe(false);
+        expect(validator(spec, '')).toBe(false);
         expect(validator(spec, '1.01')).toBe(ErrorMessages.minNumber(spec.minimum));
         expect(validator(spec, 1.01)).toBe(ErrorMessages.minNumber(spec.minimum));
         expect(validator(spec, 101)).toBe(false);

--- a/src/lib/kit/validators/validators.ts
+++ b/src/lib/kit/validators/validators.ts
@@ -137,7 +137,8 @@ export const getNumberValidator = (params: GetNumberValidatorParams = {}) => {
         if (
             !ignoreMinimumCheck &&
             _.isNumber(spec.minimum) &&
-            ((stringValue.length && spec.minimum > Number(stringValue)) || !stringValue.length)
+            stringValue.length &&
+            spec.minimum > Number(stringValue)
         ) {
             return ErrorMessages.minNumber(spec.minimum);
         }


### PR DESCRIPTION
This PR disables numbers minimum check when input is empty