### PR TITLE
feat: ignore minimum check when a number field is empty

### DIFF
--- a/src/lib/kit/validators/__tests__/validators.test.ts
+++ b/src/lib/kit/validators/__tests__/validators.test.ts
@@ -83,6 +83,7 @@ describe('kit/validators/validators', () => {
         spec.minimum = 100.5;
 
         expect(getNumberValidator({ignoreMinimumCheck: true})(spec, '1.01')).toBe(false);
+        expect(validator(spec, '')).toBe(false);
         expect(validator(spec, '1.01')).toBe(ErrorMessages.minNumber(spec.minimum));
         expect(validator(spec, 1.01)).toBe(ErrorMessages.minNumber(spec.minimum));
         expect(validator(spec, 101)).toBe(false);

--- a/src/lib/kit/validators/validators.ts
+++ b/src/lib/kit/validators/validators.ts
@@ -137,7 +137,8 @@ export const getNumberValidator = (params: GetNumberValidatorParams = {}) => {
         if (
             !ignoreMinimumCheck &&
             _.isNumber(spec.minimum) &&
-            ((stringValue.length && spec.minimum > Number(stringValue)) || !stringValue.length)
+            stringValue.length &&
+            spec.minimum > Number(stringValue)
         ) {
             return ErrorMessages.minNumber(spec.minimum);
         }


### PR DESCRIPTION
This PR disables numbers minimum check when input is empty