### PR TITLE
fix(helpPopoverRow): fixed row help popover

### DIFF
--- a/src/lib/kit/components/Layouts/Row/Row.scss
+++ b/src/lib/kit/components/Layouts/Row/Row.scss
@@ -50,6 +50,7 @@
 
     &__note {
         padding-right: 16px;
+        position: relative;
 
         &-inner {
             position: absolute;


### PR DESCRIPTION
as it was
![image](https://github.com/gravity-ui/dynamic-forms/assets/23384737/76b8b401-11d8-42e2-868d-8544c1591191)
after correction
<img width="849" alt="image" src="https://github.com/gravity-ui/dynamic-forms/assets/23384737/cb49c7de-db53-4749-a164-2e7cdec8273f">

