### PR TITLE
feat(TableArrayInput): add wordWrap prop

### DIFF
--- a/src/lib/core/types/specs.ts
+++ b/src/lib/core/types/specs.ts
@@ -32,6 +32,7 @@ export interface ArraySpec<
             label: string;
             property: string;
         }[];
+        tableWordWrap?: boolean;
         link?: LinkType;
         placeholder?: string;
         addButtonPosition?: 'down' | 'right';

--- a/src/lib/kit/components/Inputs/TableArrayInput/TableArrayInput.tsx
+++ b/src/lib/kit/components/Inputs/TableArrayInput/TableArrayInput.tsx
@@ -175,6 +175,7 @@ export const TableArrayInput: ArrayInput = ({spec, name, arrayInput, input}) => 
                     getRowId={(_, idx) => `${name}-${idx}`}
                     verticalAlign="top"
                     getRowClassNames={getRowClassNames}
+                    wordWrap={spec.viewSpec.tableWordWrap}
                 />
             ) : null}
             {!arrayInput.value && spec.defaultValue ? (

--- a/src/stories/ArrayBase.stories.tsx
+++ b/src/stories/ArrayBase.stories.tsx
@@ -37,6 +37,7 @@ const excludeOptions = [
     'description',
     'viewSpec.type',
     'viewSpec.table',
+    'viewSpec.tableWordWrap',
     'viewSpec.placeholder',
     'viewSpec.selectParams',
 ];

--- a/src/stories/ArraySelect.stories.tsx
+++ b/src/stories/ArraySelect.stories.tsx
@@ -54,6 +54,7 @@ const excludeOptions = [
     'viewSpec.type',
     'viewSpec.itemLabel',
     'viewSpec.table',
+    'viewSpec.tableWordWrap',
     'viewSpec.itemPrefix',
     'viewSpec.addButtonPosition',
 ];

--- a/src/stories/ObjectMultiOneOf.stories.tsx
+++ b/src/stories/ObjectMultiOneOf.stories.tsx
@@ -60,6 +60,7 @@ const excludeOptions = [
     'viewSpec.type',
     'viewSpec.itemLabel',
     'viewSpec.table',
+    'viewSpec.tableWordWrap',
     'viewSpec.oneOfParams',
     'viewSpec.delimiter',
 ];

--- a/src/stories/ObjectMultiOneOfFlat.stories.tsx
+++ b/src/stories/ObjectMultiOneOfFlat.stories.tsx
@@ -60,6 +60,7 @@ const excludeOptions = [
     'viewSpec.type',
     'viewSpec.itemLabel',
     'viewSpec.table',
+    'viewSpec.tableWordWrap',
     'viewSpec.oneOfParams',
     'viewSpec.delimiter',
 ];

--- a/src/stories/components/InputPreview/constants.ts
+++ b/src/stories/components/InputPreview/constants.ts
@@ -211,6 +211,11 @@ const layoutOpen: BooleanSpec = {
     viewSpec: {type: 'base', layout: 'row', layoutTitle: 'Layout open'},
 };
 
+const tableWordWrap: BooleanSpec = {
+    type: SpecTypes.Boolean,
+    viewSpec: {type: 'base', layout: 'row', layoutTitle: 'Table word wrap'},
+};
+
 const itemLabel: StringSpec = {
     type: SpecTypes.String,
     viewSpec: {type: 'base', layout: 'row', layoutTitle: 'Item label'},
@@ -502,6 +507,7 @@ export const getArrayOptions = (): ObjectSpec => ({
                 itemLabel,
                 itemPrefix,
                 table,
+                tableWordWrap,
                 placeholder,
                 addButtonPosition,
                 hidden,
@@ -517,6 +523,7 @@ export const getArrayOptions = (): ObjectSpec => ({
                 'itemLabel',
                 'itemPrefix',
                 'table',
+                'tableWordWrap',
                 'placeholder',
                 'addButtonPosition',
                 'hidden',


### PR DESCRIPTION
How its look right not:
<img width="2012" alt="Screenshot 2024-03-14 at 1 42 50 PM" src="https://github.com/gravity-ui/dynamic-forms/assets/14909082/7f0868fb-b29f-41aa-90c2-ec1fb6a7559b">

How its look with prop:
![image](https://github.com/gravity-ui/dynamic-forms/assets/14909082/a17d2c32-7219-462c-b60a-0d8f135cb2b8)

Spec example:
```
{
  "type": "array",
  "items": {
    "type": "object",
    "properties": {
      "key": {
        "type": "string",
        "viewSpec": {
          "type": "base",
          "layout": "table_item"
        }
      },
      "value": {
        "required": true,
        "type": "object",
        "properties": {
          "resourcemanager_address": {
            "type": "string",
            "viewSpec": {
              "type": "base",
              "layout": "row",
              "layoutTitle": "Resourcemanager address"
              }
          },
          "resourcemanager_scheduler_address": {
            "type": "string",
            "viewSpec": {
              "type": "base",
              "layout": "row",
              "layoutTitle": "Resourcemanager scheduler address"
            }
          },
          "resourcemanager_resource_tracker_address": {
            "type": "string",
            "viewSpec": {
              "type": "base",
              "layout": "row",
              "layoutTitle": "Resourcemanager resource tracker address"
            }
          }
        },
        "viewSpec": {
          "type": "base",
          "layout": "transparent"
        }
      }
    },
    "viewSpec": {
      "type": ""
    }
  },
  "viewSpec": {
    "type": "table",
    "layout": "accordeon",
    "layoutTitle": "Ha rms",
    "layoutOpen": true,
    "itemLabel": "Ha rm",
    "table": [
      {
        "label": "key",
        "property": "key"
      },
      {
        "label": "value",
        "property": "value"
      }
    ]
  }
}
```
