### PR TITLE
fix: prevent useMutators from using previous call arguments

### DIFF
--- a/src/lib/core/components/Form/hooks/useMutators.ts
+++ b/src/lib/core/components/Form/hooks/useMutators.ts
@@ -53,7 +53,7 @@ export const useMutators = (externalMutators?: DynamicFormMutators) => {
                 a: Record<string, {value: T}> = {},
                 b: Record<string, T>,
             ) => {
-                const result = cloneDeep(a);
+                const result = {...a};
 
                 Object.keys(b).forEach((key) => {
                     set(result, [key, 'value'], b[key]);


### PR DESCRIPTION
When calling useMutators in a component that is used for two fields within the same form, changes to one field affect the other because the arguments passed to mutate are stored in internal state and are added to each subsequent call.

This problem is described in https://github.com/gravity-ui/dynamic-forms/issues/291