### PR TITLE
fix: support numeric values in array enums

### DIFF
--- a/src/lib/core/types/specs.ts
+++ b/src/lib/core/types/specs.ts
@@ -15,7 +15,7 @@ export interface ArraySpec<
     maxLength?: bigint;
     minLength?: bigint;
     items?: Spec;
-    enum?: string[];
+    enum?: Array<string | number>;
     description?: Record<string, string>;
     validator?: string;
     viewSpec: {

--- a/src/lib/kit/components/Inputs/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/lib/kit/components/Inputs/CheckboxGroup/CheckboxGroup.tsx
@@ -19,8 +19,8 @@ export interface CheckboxGroupProps
 export const CheckboxGroup: ArrayInput<CheckboxGroupProps> = ({name, input, spec, inputProps}) => {
     const {value, onBlur, onChange, onFocus} = input;
 
-    const _value: string[] | undefined = React.useMemo(
-        () => transformArrOut<FieldArrayValue, string[]>(value),
+    const _value: Array<string | number> | undefined = React.useMemo(
+        () => transformArrOut<FieldArrayValue, Array<string | number>>(value),
         [value],
     );
 
@@ -34,7 +34,7 @@ export const CheckboxGroup: ArrayInput<CheckboxGroupProps> = ({name, input, spec
     );
 
     const handleUpdate = React.useCallback(
-        (optionValue: string, selected: boolean) => {
+        (optionValue: string | number, selected: boolean) => {
             let newValue = _value || [];
 
             if (selected) {
@@ -43,7 +43,7 @@ export const CheckboxGroup: ArrayInput<CheckboxGroupProps> = ({name, input, spec
                 newValue = newValue.filter((id) => id !== optionValue);
             }
 
-            onChange(transformArrIn<string[], FieldArrayValue>(newValue));
+            onChange(transformArrIn<Array<string | number>, FieldArrayValue>(newValue));
         },
         [_value, onChange],
     );

--- a/src/lib/kit/components/Inputs/MultiSelect/MultiSelect.tsx
+++ b/src/lib/kit/components/Inputs/MultiSelect/MultiSelect.tsx
@@ -37,22 +37,27 @@ export const MultiSelect: ArrayInput<MultiSelectProps> = ({name, input, spec, in
         () =>
             withCustomOptions
                 ? externalOptions || []
-                : spec.enum?.map((id) => ({
-                      id,
-                      value: id,
-                      text: spec.description?.[id] || id,
-                      content: spec.viewSpec.selectParams?.meta?.[id] ? (
-                          <div key={id}>
-                              <Text>{spec.description?.[id] || id}</Text>
-                              <Text color="secondary" className={b('meta-text')}>
-                                  {spec.viewSpec.selectParams.meta[id]}
-                              </Text>
-                          </div>
-                      ) : (
-                          spec.description?.[id] || id
-                      ),
-                      key: id,
-                  })),
+                : spec.enum?.map((enumValue) => {
+                      const value = String(enumValue);
+                      const text = spec.description?.[value] || value;
+
+                      return {
+                          id: value,
+                          value,
+                          text,
+                          content: spec.viewSpec.selectParams?.meta?.[value] ? (
+                              <div key={value}>
+                                  <Text>{text}</Text>
+                                  <Text color="secondary" className={b('meta-text')}>
+                                      {spec.viewSpec.selectParams.meta[value]}
+                                  </Text>
+                              </div>
+                          ) : (
+                              text
+                          ),
+                          key: value,
+                      };
+                  }),
         [
             spec.enum,
             spec.description,
@@ -85,11 +90,22 @@ export const MultiSelect: ArrayInput<MultiSelectProps> = ({name, input, spec, in
         [onFocus, onBlur],
     );
 
-    const _value = React.useMemo(() => transformArrOut<FieldArrayValue, string[]>(value), [value]);
+    const _value = React.useMemo(
+        () => transformArrOut<FieldArrayValue, Array<string | number>>(value).map(String),
+        [value],
+    );
 
     const handleChange = React.useCallback(
-        (value: string[]) => onChange(transformArrIn<string[], FieldArrayValue>(value)),
-        [onChange],
+        (value: string[]) => {
+            const enumValues = value.map(
+                (selectedValue) =>
+                    spec.enum?.find((enumValue) => String(enumValue) === selectedValue) ??
+                    selectedValue,
+            );
+
+            onChange(transformArrIn<Array<string | number>, FieldArrayValue>(enumValues));
+        },
+        [onChange, spec.enum],
     );
 
     return (

--- a/src/lib/kit/components/Inputs/MultiSelect/MultiSelect.tsx
+++ b/src/lib/kit/components/Inputs/MultiSelect/MultiSelect.tsx
@@ -91,7 +91,10 @@ export const MultiSelect: ArrayInput<MultiSelectProps> = ({name, input, spec, in
     );
 
     const _value = React.useMemo(
-        () => transformArrOut<FieldArrayValue, Array<string | number>>(value).map(String),
+        () =>
+            transformArrOut<FieldArrayValue, Array<string | number> | undefined>(value)?.map(
+                String,
+            ),
         [value],
     );
 

--- a/src/lib/kit/components/Inputs/MultiSelect/__tests__/MultiSelect.number-enum.test.tsx
+++ b/src/lib/kit/components/Inputs/MultiSelect/__tests__/MultiSelect.number-enum.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import {ThemeProvider} from '@gravity-ui/uikit';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import {Form} from 'react-final-form';
+
+import {type ArraySpec, DynamicField, SpecTypes} from '../../../../../core';
+import {dynamicConfig} from '../../../../constants';
+
+beforeEach(() => {
+    window.matchMedia = () => ({
+        media: '',
+        matches: false,
+        onchange: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+    });
+});
+
+const renderNumberEnum = (values: number[]) => {
+    const spec: ArraySpec = {
+        type: SpecTypes.Array,
+        enum: values,
+        defaultValue: [3],
+        viewSpec: {
+            type: 'select',
+            layout: 'row',
+        },
+    };
+
+    render(
+        <ThemeProvider>
+            <Form initialValues={{input: [3]}} onSubmit={noop}>
+                {({values}) => (
+                    <>
+                        <DynamicField name="input" spec={spec} config={dynamicConfig} />
+                        <output data-testid="value">{JSON.stringify(values.input)}</output>
+                    </>
+                )}
+            </Form>
+        </ThemeProvider>,
+    );
+
+    return screen.getByText('3');
+};
+
+test('renders an array select with nine numeric enum options', () => {
+    expect(renderNumberEnum([1, 2, 3, 4, 5, 6, 7, 8, 9])).toBeVisible();
+});
+
+test('renders an array select with ten numeric enum options', () => {
+    expect(renderNumberEnum([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toBeVisible();
+});
+
+test('keeps numeric enum values after selection', async () => {
+    const user = userEvent.setup();
+
+    renderNumberEnum([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('option', {name: '4'}));
+
+    await waitFor(() => {
+        expect(screen.getByTestId('value')).toHaveTextContent('[3,4]');
+    });
+});

--- a/src/lib/kit/components/Inputs/MultiSelect/__tests__/MultiSelect.number-enum.test.tsx
+++ b/src/lib/kit/components/Inputs/MultiSelect/__tests__/MultiSelect.number-enum.test.tsx
@@ -22,11 +22,11 @@ beforeEach(() => {
     });
 });
 
-const renderNumberEnum = (values: number[]) => {
+const renderNumberEnum = (values: number[], initialValue: number[] | undefined = [3]) => {
     const spec: ArraySpec = {
         type: SpecTypes.Array,
         enum: values,
-        defaultValue: [3],
+        defaultValue: initialValue,
         viewSpec: {
             type: 'select',
             layout: 'row',
@@ -35,7 +35,7 @@ const renderNumberEnum = (values: number[]) => {
 
     render(
         <ThemeProvider>
-            <Form initialValues={{input: [3]}} onSubmit={noop}>
+            <Form initialValues={{input: initialValue}} onSubmit={noop}>
                 {({values}) => (
                     <>
                         <DynamicField name="input" spec={spec} config={dynamicConfig} />
@@ -55,6 +55,12 @@ test('renders an array select with nine numeric enum options', () => {
 
 test('renders an array select with ten numeric enum options', () => {
     expect(renderNumberEnum([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toBeVisible();
+});
+
+test('renders an array select without an initial value', () => {
+    renderNumberEnum([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], undefined);
+
+    expect(screen.getByRole('combobox')).toBeVisible();
 });
 
 test('keeps numeric enum values after selection', async () => {


### PR DESCRIPTION
## Summary

- allow numeric values in array enum specs
- stringify numeric enum options for UIKit rendering and filtering
- restore original numeric values on selection
- cover the 9/10-option boundary and numeric value preservation with tests

## Testing

- `npm test -- --runInBand`
- `npm run typecheck`
- ESLint and Prettier on changed files

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.